### PR TITLE
suggestions to PR #187

### DIFF
--- a/ros_ign_bridge/CMakeLists.txt
+++ b/ros_ign_bridge/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
+find_package(ros_ign_interfaces REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2_msgs REQUIRED)
@@ -78,6 +79,7 @@ ament_target_dependencies(${bridge_lib}
   "nav_msgs"
   "rclcpp"
   "rosgraph_msgs"
+  "ros_ign_interfaces"
   "sensor_msgs"
   "std_msgs"
   "tf2_msgs"
@@ -100,18 +102,18 @@ ament_export_libraries(${bridge_lib})
 foreach(bridge ${bridge_executables})
   add_executable(${bridge}
     src/${bridge}.cpp
-    ${common_sources}
   )
   target_link_libraries(${bridge}
     ignition-msgs${IGN_MSGS_VER}::core
     ignition-transport${IGN_TRANSPORT_VER}::core
+    ${bridge_lib}
   )
   ament_target_dependencies(${bridge}
-    "ros_ign_interfaces"
     "geometry_msgs"
     "nav_msgs"
     "rclcpp"
     "rosgraph_msgs"
+    "ros_ign_interfaces"
     "sensor_msgs"
     "std_msgs"
     "tf2_msgs"

--- a/ros_ign_bridge/package.xml
+++ b/ros_ign_bridge/package.xml
@@ -17,6 +17,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rosgraph_msgs</depend>
+  <depend>ros_ign_interfaces</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2_msgs</depend>

--- a/ros_ign_interfaces/CMakeLists.txt
+++ b/ros_ign_interfaces/CMakeLists.txt
@@ -36,10 +36,9 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs 
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
   ADD_LINTER_TESTS
 )
 
-ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rosidl_default_runtime)
 ament_package()


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

@WilliamLewww I made here some suggestions:

 - you don't need to export the library with `ament_export_libraries` if it's just a msgs package.
 - You were not able to find `ros_ign_interfaces` because you need to find it with `find_package` and add this new dependency to the `package.xml` (for the topological order)
 -  ${common_sources} was compiled as a library, I made a small change, I used this shared library instead of compiling the code again.